### PR TITLE
feat: added login context with localstorage

### DIFF
--- a/front/.eslintrc.json
+++ b/front/.eslintrc.json
@@ -21,6 +21,8 @@
     "rules": {
         "react/react-in-jsx-scope": "off",
         "react/jsx-uses-react": "off",
-        "react/prop-types": "off"
+        "react/prop-types": "off",
+        "no-empty-function": "off",
+        "@typescript-eslint/no-empty-function": "off"
     }
 }

--- a/front/package.json
+++ b/front/package.json
@@ -24,7 +24,8 @@
     "react-websitecarbon-badge": "^1.0.5",
     "typescript": "^4.9.5",
     "web-vitals": "^2.1.4",
-    "yup": "^1.2.0"
+    "yup": "^1.2.0",
+    "zod": "^3.22.2"
   },
   "scripts": {
     "start": "react-scripts start",

--- a/front/src/App.tsx
+++ b/front/src/App.tsx
@@ -1,27 +1,18 @@
-import { Routes, Route } from "react-router-dom";
-import "./App.css";
+import './App.css';
 
-import CanvasPage from "./pages/CanvasPage";
-import LoginPage from "./pages/LoginPage";
-import HomePage from "./pages/HomePage";
-import HeaderBar from "./components/Header";
-import Dashboard from "./pages/Dashboard";
+import HeaderBar from './components/Header';
 
-import { Box, ThemeProvider } from "@mui/material";
-import theme from "./theme";
-import Footer from "./components/Footer";
+import { Box, ThemeProvider } from '@mui/material';
+import theme from './theme';
+import Footer from './components/Footer';
+import Navigator from './Navigator';
 
 function App() {
   return (
     <ThemeProvider theme={theme}>
       <Box>
         <HeaderBar />
-        <Routes>
-          <Route path="/" element={<HomePage />} />
-          <Route path="/login" element={<LoginPage />} />
-          <Route path="/canvas" element={<CanvasPage />} />
-          <Route path="/dashboard" element={<Dashboard />} />
-        </Routes>
+        <Navigator />
         <Footer />
       </Box>
     </ThemeProvider>

--- a/front/src/App.tsx
+++ b/front/src/App.tsx
@@ -6,15 +6,18 @@ import { Box, ThemeProvider } from '@mui/material';
 import theme from './theme';
 import Footer from './components/Footer';
 import Navigator from './Navigator';
+import { LoginContextProvider } from './hooks/useLoginContext';
 
 function App() {
   return (
     <ThemeProvider theme={theme}>
-      <Box>
-        <HeaderBar />
-        <Navigator />
-        <Footer />
-      </Box>
+      <LoginContextProvider>
+        <Box>
+          <HeaderBar />
+          <Navigator />
+          <Footer />
+        </Box>
+      </LoginContextProvider>
     </ThemeProvider>
   );
 }

--- a/front/src/Navigator.tsx
+++ b/front/src/Navigator.tsx
@@ -1,0 +1,22 @@
+import { FC, useContext } from 'react';
+import { LoginContext } from './hooks/useLoginContext';
+import { Navigate, Route, Routes } from 'react-router-dom';
+import HomePage from './pages/HomePage';
+import LoginPage from './pages/LoginPage';
+import CanvasPage from './pages/CanvasPage';
+
+const Navigator: FC = () => {
+  const { isLoggedIn } = useContext(LoginContext);
+  console.log('isLoggedIn', isLoggedIn);
+
+  return (
+    <Routes>
+      <Route path="/" element={<HomePage />} />
+      {isLoggedIn ? <Route path="/login" element={<LoginPage />} /> : null}
+      {isLoggedIn ? <Route path="/canvas" element={<CanvasPage />} /> : null}
+      <Route path="*" element={<Navigate to="/" />} />
+    </Routes>
+  );
+};
+
+export default Navigator;

--- a/front/src/Navigator.tsx
+++ b/front/src/Navigator.tsx
@@ -12,7 +12,7 @@ const Navigator: FC = () => {
   return (
     <Routes>
       <Route path="/" element={<HomePage />} />
-      {isLoggedIn ? <Route path="/login" element={<LoginPage />} /> : null}
+      <Route path="/login" element={<LoginPage />} />
       {isLoggedIn ? <Route path="/canvas" element={<CanvasPage />} /> : null}
       <Route path="*" element={<Navigate to="/" />} />
     </Routes>

--- a/front/src/Navigator.tsx
+++ b/front/src/Navigator.tsx
@@ -7,7 +7,6 @@ import CanvasPage from './pages/CanvasPage';
 
 const Navigator: FC = () => {
   const { isLoggedIn } = useContext(LoginContext);
-  console.log('isLoggedIn', isLoggedIn);
 
   return (
     <Routes>

--- a/front/src/Navigator.tsx
+++ b/front/src/Navigator.tsx
@@ -4,6 +4,7 @@ import { Navigate, Route, Routes } from 'react-router-dom';
 import HomePage from './pages/HomePage';
 import LoginPage from './pages/LoginPage';
 import CanvasPage from './pages/CanvasPage';
+import Dashboard from './pages/Dashboard';
 
 const Navigator: FC = () => {
   const { isLoggedIn } = useContext(LoginContext);
@@ -13,6 +14,7 @@ const Navigator: FC = () => {
       <Route path="/" element={<HomePage />} />
       <Route path="/login" element={<LoginPage />} />
       {isLoggedIn ? <Route path="/canvas" element={<CanvasPage />} /> : null}
+      <Route path="/dashboard" element={<Dashboard />} />
       <Route path="*" element={<Navigate to="/" />} />
     </Routes>
   );

--- a/front/src/helpers/localStorageObjectSchema.ts
+++ b/front/src/helpers/localStorageObjectSchema.ts
@@ -1,0 +1,18 @@
+import { z } from 'zod';
+
+const localStorageObjectSchema = z
+  .string()
+  .nullable()
+  .transform<unknown>((data) => {
+    if (!data) {
+      return null;
+    }
+
+    try {
+      return JSON.parse(data);
+    } catch {
+      return null;
+    }
+  });
+
+export default localStorageObjectSchema;

--- a/front/src/hooks/useLoginContext/index.tsx
+++ b/front/src/hooks/useLoginContext/index.tsx
@@ -1,0 +1,38 @@
+import {
+  Dispatch,
+  FC,
+  SetStateAction,
+  createContext,
+  useMemo,
+  useState,
+} from 'react';
+import { getUserTokenFromLocalStorage } from './localStorage';
+
+interface LoginContextType {
+  isLoggedIn: boolean;
+  setIsLoggedIn: Dispatch<SetStateAction<boolean>>;
+}
+
+export const LoginContext = createContext<LoginContextType>({
+  isLoggedIn: false,
+  setIsLoggedIn: () => {},
+});
+
+export const LoginContextProvider: FC<{ children: React.ReactNode }> = ({
+  children,
+}) => {
+  const userTokenData = useMemo(() => getUserTokenFromLocalStorage(), []);
+
+  const [isLoggedIn, setIsLoggedIn] = useState(!!userTokenData?.userToken);
+
+  const providerValue = useMemo(
+    () => ({ isLoggedIn, setIsLoggedIn }),
+    [isLoggedIn, setIsLoggedIn],
+  );
+
+  return (
+    <LoginContext.Provider value={providerValue}>
+      {children}
+    </LoginContext.Provider>
+  );
+};

--- a/front/src/hooks/useLoginContext/localStorage.ts
+++ b/front/src/hooks/useLoginContext/localStorage.ts
@@ -1,0 +1,39 @@
+import localStorageObjectSchema from '../../helpers/localStorageObjectSchema';
+import { z } from 'zod';
+
+interface LocalStorageUserToken {
+  userToken?: string;
+}
+
+const LocalStorageUserTokenSchema = z.record(
+  z.object({
+    userToken: z.optional(z.string()),
+  }),
+);
+
+const USER_TOKEN_LOCAL_STORAGE_KEY = 'hasLoggedIn';
+
+export const getUserTokenFromLocalStorage =
+  (): LocalStorageUserToken | null => {
+    const userTokenData = localStorageObjectSchema
+      .pipe(LocalStorageUserTokenSchema)
+      .safeParse(window.localStorage.getItem(USER_TOKEN_LOCAL_STORAGE_KEY));
+    if (userTokenData.success) {
+      return userTokenData.data;
+    }
+
+    return null;
+  };
+
+export const saveUserTokenInLocalStorage = (
+  userTokenObj: LocalStorageUserToken,
+) => {
+  window.localStorage.setItem(
+    USER_TOKEN_LOCAL_STORAGE_KEY,
+    JSON.stringify(userTokenObj),
+  );
+};
+
+export const removeUserTokenFromLocalStorage = () => {
+  window.localStorage.removeItem(USER_TOKEN_LOCAL_STORAGE_KEY);
+};

--- a/front/src/hooks/useLoginContext/localStorage.ts
+++ b/front/src/hooks/useLoginContext/localStorage.ts
@@ -11,7 +11,7 @@ const LocalStorageUserTokenSchema = z.record(
   }),
 );
 
-const USER_TOKEN_LOCAL_STORAGE_KEY = 'hasLoggedIn';
+const USER_TOKEN_LOCAL_STORAGE_KEY = 'userTokenData';
 
 export const getUserTokenFromLocalStorage =
   (): LocalStorageUserToken | null => {


### PR DESCRIPTION
## Description
- Added a login context to handle routes access based on user login status

`LoginContext` will check in local storage if the user has a `userToken`: if they do, `isLoggedIn` is true, false if not (meaning the user has either logged out or didn't check the "remember me" checkbox). 

Within the provider, we can extract `isLoggedIn` using `useContext` to block access to certain routes (like `/canvas` in this example) and will automatically redirect to `/`  if user is not logged in.

I added `zod` library to handle local storage typing. By default, anything returned by `window.localStorage.getItem` is of type `string | null` and when you parse it with `JSON.parse`, you don't know if the object is of desired type.
 zod allows us to add some typing and safely parse data to make typescript use easier.
