### PR TITLE
Fix login & removeFriend & updateArticle & updateExpense resolvers

### DIFF
--- a/back/src/entity/Article.ts
+++ b/back/src/entity/Article.ts
@@ -37,6 +37,8 @@ export class Article {
   updatedAt: Date;
 
   @Field(() => User)
-  @ManyToOne(() => User, (user) => user.articles)
+  @ManyToOne(() => User, (user) => user.articles, {
+    onDelete: 'CASCADE',
+  })
   user: User;
 }

--- a/back/src/entity/Expense.ts
+++ b/back/src/entity/Expense.ts
@@ -38,10 +38,14 @@ export class Expense {
   updatedAt: Date;
 
   @Field(() => User)
-  @ManyToOne(() => User, (user) => user.expenses)
+  @ManyToOne(() => User, (user) => user.expenses, {
+    onDelete: 'CASCADE',
+  })
   user: User;
 
   @Field(() => Item)
-  @ManyToOne(() => Item, (item) => item.expenses)
+  @ManyToOne(() => Item, (item) => item.expenses, {
+    onDelete: 'CASCADE'
+  })
   item: Item;
 }

--- a/back/src/entity/Item.ts
+++ b/back/src/entity/Item.ts
@@ -40,7 +40,9 @@ export class Item {
   updatedAt: Date;
 
   @Field(() => Category)
-  @ManyToOne(() => Category, (category) => category.items)
+  @ManyToOne(() => Category, (category) => category.items, {
+    onDelete: 'CASCADE',
+  })
   category: Category;
 
   @Field(() => [Expense])

--- a/back/src/resolver/ArticleResolver.ts
+++ b/back/src/resolver/ArticleResolver.ts
@@ -25,8 +25,10 @@ class ArticleResolver {
       article.description = description;
       article.url = url;
       article.createdAt = new Date();
-      
-      const user = await dataSource.getRepository(User).findOne({ where: { id: userId } });
+
+      const user = await dataSource
+        .getRepository(User)
+        .findOne({ where: { id: userId } });
       if (!user) {
         throw new Error(`User with ID ${userId} not found`);
       }
@@ -53,16 +55,25 @@ class ArticleResolver {
     @Arg('userId') userId: string,
   ): Promise<Article> {
     try {
-      const targetedArticle = await dataSource
-        .getRepository(Article)
-        .findOne({ where: { id: articleId } });
+      const targetedArticle = await dataSource.getRepository(Article).findOne({
+        where: {
+          id: articleId,
+        },
+        relations: {
+          user: true,
+        },
+      });
 
-      const user = await dataSource.getRepository(User).findOne({ where: { id: userId } });
+      if (!targetedArticle) throw new Error('Article not found');
+
+      const user = await dataSource
+        .getRepository(User)
+        .findOne({ where: { id: userId } });
       if (!user) {
         throw new Error(`User with ID ${userId} not found`);
       }
 
-      if (!user ) {
+      if (!user) {
         throw new Error('your not a owner to this article');
       }
 

--- a/back/src/resolver/ExpenseResolver.ts
+++ b/back/src/resolver/ExpenseResolver.ts
@@ -49,18 +49,24 @@ class ExpenseResolver {
   ): Promise<Expense> {
     const targetedExpense = await dataSource
       .getRepository(Expense)
-      .findOneByOrFail({ id });
+      .findOne({ where: { id }, relations: { user: true } });
+
+    if (!targetedExpense) throw new Error('Expense not found');
+
+    if (targetedExpense.user.id !== contextValue.jwtPayload.id) {
+      throw new Error("You're not the owner of this expense");
+    }
 
     const item = await dataSource
       .getRepository(Item)
       .findOneByOrFail({ id: itemId });
 
     if (!item) {
-      throw new Error('Item introuvable dans la base de données');
+      throw new Error('Item not found');
     }
 
-    if (quantity < 0 || quantity >= 500000 || quantity != null) {
-      throw new Error('error quantity value');
+    if (quantity < 0 || quantity >= 500000 || quantity === null) {
+      throw new Error('Quantity value is not valid');
     }
 
     targetedExpense.item = item;

--- a/back/src/resolver/UserResolver.ts
+++ b/back/src/resolver/UserResolver.ts
@@ -148,8 +148,8 @@ class UserResolver {
     if (isUserValid) {
       // we just need the user object without password
       // eslint-disable-next-line @typescript-eslint/no-unused-vars
-      const { password, ...userData } = user;
-      const token = jwt.sign(userData, 'supersecretkey');
+      const { password, articles, expenses, users, ...userData } = user;
+      const token = jwt.sign(userData, 'supersecretkey', { expiresIn: '24h' });
       const response: LoginResponse = { user, token, success: true };
       return response;
     } else {
@@ -165,18 +165,18 @@ class UserResolver {
     @Arg('userIdToAdd') userIdToAdd: string,
     @Ctx() contextValue: Context,
   ): Promise<string> {
-    const UserRepo = dataSource.getRepository(User);
+    const userRepo = dataSource.getRepository(User);
     const currentUserId = contextValue.jwtPayload?.id ?? userId;
-    const currentUser = await UserRepo.findOne({
+    const currentUser = await userRepo.findOne({
       where: { id: currentUserId },
       relations: { users: true },
     });
     if (currentUser) {
-      const friend = await UserRepo.findOneByOrFail({ id: userIdToAdd });
+      const friend = await userRepo.findOneByOrFail({ id: userIdToAdd });
       currentUser.users = currentUser.users
         ? [...currentUser.users, friend]
         : [friend];
-      await UserRepo.save(currentUser);
+      await userRepo.save(currentUser);
       return 'Friend added';
     }
     throw new Error('Something broke, try again');
@@ -188,18 +188,26 @@ class UserResolver {
     @Arg('userIdToRemove') userIdToRemove: string,
     @Ctx() contextValue: Context,
   ): Promise<string> {
-    const UserRepo = dataSource.getRepository(User);
+    const userRepo = dataSource.getRepository(User);
     const currentUserId = contextValue.jwtPayload?.id ?? userId;
-    const currentUser =
-      contextValue.jwtPayload ??
-      (await UserRepo.findOne({
-        where: { id: currentUserId },
-        relations: { users: true },
-      }));
+
+    console.log(contextValue.jwtPayload);
+
+    const currentUser = await dataSource.getRepository(User).findOne({
+      where: {
+        id: currentUserId,
+      },
+      relations: {
+        users: true,
+      },
+    });
+
+    if (!currentUser) throw new Error('User not found');
+
     currentUser.users = currentUser.users.filter(
       (friend) => friend.id !== userIdToRemove,
     );
-    await UserRepo.save(currentUser);
+    await userRepo.save(currentUser);
     return 'Friend removed';
   }
 
@@ -209,9 +217,9 @@ class UserResolver {
     @Ctx() contextValue: Context,
   ): Promise<User[] | null> {
     try {
-      const UserRepo = dataSource.getRepository(User);
+      const userRepo = dataSource.getRepository(User);
       const currentUserId = contextValue.jwtPayload?.id ?? userId;
-      const currentUser = await UserRepo.findOne({
+      const currentUser = await userRepo.findOne({
         where: { id: currentUserId },
         relations: { users: true },
       });

--- a/back/src/resolver/UserResolver.ts
+++ b/back/src/resolver/UserResolver.ts
@@ -210,28 +210,6 @@ class UserResolver {
     await userRepo.save(currentUser);
     return 'Friend removed';
   }
-
-  @Query(() => [User])
-  async getFriends(
-    @Arg('userId', { nullable: true }) userId: string,
-    @Ctx() contextValue: Context,
-  ): Promise<User[] | null> {
-    try {
-      const userRepo = dataSource.getRepository(User);
-      const currentUserId = contextValue.jwtPayload?.id ?? userId;
-      const currentUser = await userRepo.findOne({
-        where: { id: currentUserId },
-        relations: { users: true },
-      });
-      if (currentUser) {
-        return currentUser.users;
-      }
-      return null;
-    } catch (error) {
-      console.error(error);
-      throw error;
-    }
-  }
 }
 
 export default UserResolver;


### PR DESCRIPTION
getFriends --> pas utile mais laissé

removeFriend --> si le jwtPayload existe dans le contexte, la requête removeFriend tentait de supprimer un ami sur la base des infos du user contenu dans le contexte. Or les infos dans le contexte contiennent l'id, le mail et le pseudo, mais pas les références aux amis (user.users). J'ai corrigé pour que la requête aille chercher toutes les infos du user en base.

login --> lors de la création du token, même si on passe dans le payload les concernant les expenses, les articles et les amis du user, l'objet contextValue.jwtPayload ne contient que les infos mentionnées ci-dessus. Pas sûr de comprendre pourquoi. Pour être plus propre j'ai modifié le payload pour qu'il ne prenne en compte que l'id, l'email et le pseudo, comme ça on allège le token et on fait pas courir trop d'infos dans la nature.

login --> ajout d'une expiration du token après 24h

updateArticle --> erreur car la requête pour chercher l'article à updater ne récupérait pas l'id de l'utilisateur. On ne pouvait pas vérifier que l'utilisateur qui voulait update l'article était bien l'auteur.

updateExpense --> ajout d'une vérification pour savoir si le user qui veut updater l'expense en est l'auteur