### PR TITLE
fix: change node version in front/dockerfile

### DIFF
--- a/front/Dockerfile
+++ b/front/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:lts-alpine
+FROM node:18-alpine3.17
 
 WORKDIR /app
 


### PR DESCRIPTION
## Description
- Changing node version in `front/dockerfile` to fix `MaxListenersExceededWarning` issue